### PR TITLE
Tailwind CSS v4 の導入

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,8 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+}
+
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+
+


### PR DESCRIPTION
## 概要
- Tailwind v4 を導入し、開発中スタイルの土台を整備しました。
- PostCSS プラグインは `@tailwindcss/postcss`、CSS エントリは `@import "tailwindcss";` に統一。

## 変更内容
- 追加
  - `frontend/postcss.config.js`（plugins: `@tailwindcss/postcss`, `autoprefixer`）
  - `frontend/src/index.css`（`@import "tailwindcss"`）
  - `frontend/tailwind.config.js`（`content: ['./index.html','./src/**/*.{ts,tsx}']`）

## 動作確認

1) 起動確認
```bash
docker compose up
```

### 関連Issue
- #18

### 補足情報
- 特になし
