### PR TITLE
バックエンドのテスト実行フロー整備

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# 開発用ユーティリティ Makefile
+# 使い方:
+#   make backend-test     # backend の pytest を実行
+#   make backend-lint     # backend の Ruff チェックを実行
+#   make backend-all      # pytest と Ruff を一括実行
+#
+# 前提: docker compose で backend サービス名は "personal"
+#
+# コンテナ内判定について:
+# - /.dockerenv が存在すれば Docker コンテナ内とみなす（最も簡便）
+# - ただし将来のランタイム/イメージ変更で無い可能性もあるため注意
+#   代替案:
+#     1) /proc/1/cgroup を確認: grep -qE '(docker|containerd)' /proc/1/cgroup
+#     2) Dockerfile 側で ENV IN_DOCKER=1 を定義し、それを参照
+# - 必要なら上記のいずれかに切替/併用すること
+IN_DOCKER := $(shell [ -f /.dockerenv ] && echo 1 || echo 0)
+
+.PHONY: backend-test backend-lint backend-all ensure-personal
+
+ifeq ($(IN_DOCKER),1)
+PYTEST_CMD := /opt/venv/bin/pytest -q
+RUFF_CMD   := /opt/venv/bin/ruff check backend
+ENSURE :=
+else
+PYTEST_CMD := docker compose exec -T personal bash -lc "/opt/venv/bin/pytest -q"
+RUFF_CMD   := docker compose exec -T personal bash -lc "/opt/venv/bin/ruff check backend"
+ENSURE := ensure-personal
+endif
+
+ensure-personal:
+	@docker compose ps --status running --services | grep -qx personal || \
+	 (echo "コンテナ 'personal' が起動していません。'docker compose up personal' を実行してください。" && exit 1)
+
+backend-test: $(ENSURE)
+	$(PYTEST_CMD)
+
+backend-lint: $(ENSURE)
+	$(RUFF_CMD)
+
+backend-all: backend-test backend-lint

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,34 @@
+# Backend 開発ガイド
+
+## 前提
+- Docker / Docker Compose が使用可能
+- `docker compose up` で `personal` コンテナ（バックエンド）が起動済み
+
+## 起動
+```bash
+docker compose up personal
+```
+
+## テスト
+```bash
+make backend-test
+```
+
+## Lint（Ruff）
+```bash
+make backend-lint
+```
+
+## 一括（pytest → Ruff）
+```bash
+make backend-all
+```
+
+> 注: Make ターゲットは実行環境を自動判定します（コンテナ内: 直接実行 / ホスト: docker compose 経由）。
+> ホスト側ではコンテナ起動が前提です。未起動の場合はエラーとなります。
+
+## ログ（開発用）
+- `LOG_LEVEL`（既定: INFO）
+- `LOG_JSON`（既定: true）
+- `LOG_DEBUG_BODY`（既定: false）
+- `LOG_BODY_MAX`（既定: 256）


### PR DESCRIPTION
## 概要
pytest と Ruff をワンコマンドで実行できるようにし、ホスト/コンテナ内の双方で同じ操作感で運用できるようにしました。
ホスト側で未起動の際は明示エラーを返します。

## 変更内容
- Makefile
  - `/.dockerenv` による実行環境の自動判定を追加（コンテナ内＝直接実行／ホスト＝docker compose 経由）
  - `ensure-personal` を追加（未起動時はエラーで停止）
  - エラーメッセージを `docker compose` に統一
  - ターゲットを整備
    - `backend-test`: pytest
    - `backend-lint`: Ruff
    - `backend-all`: pytest → Ruff の順で実行
- backend/README.md
  - 使い方（起動/テスト/一括/Lint）と前提を記載
  - Makefile の自動判定についての注意を追記

## 動作確認
- ホストで確認
  1) `make backend-all` → 未起動時に「docker compose up personal」を促すエラーを出すこと
  2) `docker compose up personal` 実行後、`make backend-all` → pytest と Ruff が通ること
- コンテナ内で確認
  - `/usr/local/app` で `make backend-all` → 直接 `/opt/venv/bin/pytest` と `/opt/venv/bin/ruff` が実行されること

## 関連Issue
- #26

## 補足情報
- 特になし