### PR TITLE
Release v0.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# 開発用ユーティリティ Makefile
+# 使い方:
+#   make backend-test     # backend の pytest を実行
+#   make backend-lint     # backend の Ruff チェックを実行
+#   make backend-all      # pytest と Ruff を一括実行
+#
+# 前提: docker compose で backend サービス名は "personal"
+#
+# コンテナ内判定について:
+# - /.dockerenv が存在すれば Docker コンテナ内とみなす（最も簡便）
+# - ただし将来のランタイム/イメージ変更で無い可能性もあるため注意
+#   代替案:
+#     1) /proc/1/cgroup を確認: grep -qE '(docker|containerd)' /proc/1/cgroup
+#     2) Dockerfile 側で ENV IN_DOCKER=1 を定義し、それを参照
+# - 必要なら上記のいずれかに切替/併用すること
+IN_DOCKER := $(shell [ -f /.dockerenv ] && echo 1 || echo 0)
+
+.PHONY: backend-test backend-lint backend-all ensure-personal
+
+ifeq ($(IN_DOCKER),1)
+PYTEST_CMD := /opt/venv/bin/pytest -q
+RUFF_CMD   := /opt/venv/bin/ruff check backend
+ENSURE :=
+else
+PYTEST_CMD := docker compose exec -T personal bash -lc "/opt/venv/bin/pytest -q"
+RUFF_CMD   := docker compose exec -T personal bash -lc "/opt/venv/bin/ruff check backend"
+ENSURE := ensure-personal
+endif
+
+ensure-personal:
+	@docker compose ps --status running --services | grep -qx personal || \
+	 (echo "コンテナ 'personal' が起動していません。'docker compose up personal' を実行してください。" && exit 1)
+
+backend-test: $(ENSURE)
+	$(PYTEST_CMD)
+
+backend-lint: $(ENSURE)
+	$(RUFF_CMD)
+
+backend-all: backend-test backend-lint

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ PersonalMasker
 ===
 
 ## 概要
-PersonalMasker は、テキスト中の個人情報（PII）を自動検出し、マスク処理を行うバックエンド API を提供します。v0.1.0 では REST API `/mask` を提供し、検出スパンの位置（元テキスト/マスク後テキストの両方）とマスク済みテキストを返します。
+PersonalMasker は、テキスト中の個人情報（PII）を自動検出し、マスク処理を行うバックエンド API を提供します。
+v0.2.0 では REST API `/mask` を提供し、検出スパンの位置（元テキスト/マスク後テキストの両方）とマスク済みテキストを返します。
 
 ## クイックスタート
 ### 前提
@@ -10,64 +11,43 @@ PersonalMasker は、テキスト中の個人情報（PII）を自動検出し�
 
 ### 起動
 ```bash
-docker-compose up
+docker compose up
 ```
 - ヘルスチェック: `GET http://localhost:8000/health` → `{ "status": "healthy" }`
 - OpenAPI: `docs/api/openapi.v1.json`
 - FastAPI ドキュメント: `http://localhost:8000/docs`
 
-### 例: マスキング API
-- エンドポイント: `POST /mask`
-- リクエスト例
+### フロントエンド（Playground）から試す
+バックエンドに直接リクエストせず、フロントエンドのPlaygroundから `/mask` を呼び出せます（Vite の dev proxy を利用）。
+
+#### 起動
 ```bash
-curl -sS -X POST http://localhost:8000/mask \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "text": "東京都の太郎はメール taro@example.com に連絡した。",
-    "targets": ["PERSON","LOCATION","ORGANIZATION","EMAIL","PHONE","URL"],
-    "masking": {"replacement": "＊", "preserve_length": true}
-  }'
-```
-- レスポンス（概要）
-```json
-{
-  "original": "...",
-  "masked": "...",
-  "detected": [
-    {
-      "label": "PERSON",
-      "text": "太郎",
-      "start_char": 4,
-      "end_char": 6,
-      "masked_start": 4,
-      "masked_end": 6
-    },
-    {
-      "label": "EMAIL",
-      "text": "taro@example.com",
-      "start_char": 11,
-      "end_char": 27,
-      "masked_start": 11,
-      "masked_end": 33
-    }
-  ]
-}
+# バックエンドとフロントの両方を起動
+docker compose up
 ```
 
-### マスキングオプション
-- `targets?: string[]`（既定: `[PERSON, LOCATION, ORGANIZATION, EMAIL, PHONE, URL]`）
-- `masking?: { replacement?: string; preserve_length?: boolean; fixed_length?: number|null }`
-  - `preserve_length=true`（既定）: 元の長さを維持
-  - `fixed_length` 指定時: 常にその長さ
-  - `preserve_length=false` かつ `fixed_length` 未指定: `replacement` を1回だけ
-- `detected[].start_char/end_char`: 元テキスト基準
-- `detected[].masked_start/masked_end`: マスク後テキスト基準
+#### アクセス
+- Playground: `http://localhost:5173`
+- 入力欄にテキストを貼り付け、「マスクを実行」を押すと結果（マスク済みテキスト/検出一覧/差分）が表示されます。
+
+補足:
+- フロントの開発サーバは `/mask` を `http://personal:8000` にプロキシします（`frontend/vite.config.ts`）。
+- そのため、基本はブラウザ操作のみで確認可能です。
+
+
+## 環境変数（ログ関連）
+| 変数名 | 既定値 | 説明 | 備考 |
+|---|---|---|---|
+| `LOG_LEVEL` | `INFO` | ログレベル | `DEBUG`/`INFO`/`WARN` など |
+| `LOG_JSON` | `true` | ログをJSON形式で出力 | `false` でテキスト出力 |
+| `LOG_DEBUG_BODY` | `false` | デバッグ時のみ本文をログに出力 | PII注意・本番では無効推奨 |
+| `LOG_BODY_MAX` | `256` | 本文/プレビューの最大長 | 文字数上限 |
+| `LOG_SAMPLE` | `1.0` | サンプリング率 | 将来拡張用 |
 
 ## 開発
-### テスト/Lint（Docker コンテナ内実行）
-- テスト: `make test`
-- Lint: `make lint`
-- フォーマット: `make fmt`
+開発時のテスト/Lint 実行はルートの Makefile から行えます（コンテナ起動が前提）。
+
+詳細は `backend/README.md` を参照してください。
 
 ### OpenAPI の再生成
 ```bash
@@ -75,12 +55,14 @@ docker exec -w /usr/local/app personal \
   python backend/scripts/export_openapi.py --out docs/api/openapi.v1.json
 ```
 
-## プロジェクトの状態（v0.1.0）
+## プロジェクトの状態（v0.2.0）
 - 実装済み
   - `/mask` API（文分割 → GiNZA NER → 正規表現補完 → スパンマージ → マスク）
   - OpenAPI 固定化（`docs/api/openapi.v1.json`）
   - テスト（`backend/tests/...`）
   - Ruff（`backend/ruff.toml`）、CI（`.github/workflows/ruff.yml`）
+  - アクセスログ（IN/OUT、`request_id`、ローカルタイム `ts`、デバッグ時のみ本文/プレビュー）
+  - Makefile によるテスト実行フロー（コンテナ内/外の自動判定）
 - 今後
   - 文分割の精度チューニング
   - 追加エンティティ/ルール、ユーザ辞書の検討

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ PersonalMasker
 
 ## 概要
 PersonalMasker は、テキスト中の個人情報（PII）を自動検出し、マスク処理を行うバックエンド API を提供します。
-v0.2.0 では REST API `/mask` を提供し、検出スパンの位置（元テキスト/マスク後テキストの両方）とマスク済みテキストを返します。
 
 ## クイックスタート
 ### 前提
@@ -55,15 +54,12 @@ docker exec -w /usr/local/app personal \
   python backend/scripts/export_openapi.py --out docs/api/openapi.v1.json
 ```
 
-## プロジェクトの状態（v0.2.0）
+## プロジェクトの状態（v0.3.0）
 - 実装済み
   - `/mask` API（文分割 → GiNZA NER → 正規表現補完 → スパンマージ → マスク）
   - OpenAPI 固定化（`docs/api/openapi.v1.json`）
   - テスト（`backend/tests/...`）
-  - Ruff（`backend/ruff.toml`）、CI（`.github/workflows/ruff.yml`）
-  - アクセスログ（IN/OUT、`request_id`、ローカルタイム `ts`、デバッグ時のみ本文/プレビュー）
   - Makefile によるテスト実行フロー（コンテナ内/外の自動判定）
 - 今後
   - 文分割の精度チューニング
   - 追加エンティティ/ルール、ユーザ辞書の検討
-  - フロントエンド/運用ドキュメントの拡充

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,34 @@
+# Backend 開発ガイド
+
+## 前提
+- Docker / Docker Compose が使用可能
+- `docker compose up` で `personal` コンテナ（バックエンド）が起動済み
+
+## 起動
+```bash
+docker compose up personal
+```
+
+## テスト
+```bash
+make backend-test
+```
+
+## Lint（Ruff）
+```bash
+make backend-lint
+```
+
+## 一括（pytest → Ruff）
+```bash
+make backend-all
+```
+
+> 注: Make ターゲットは実行環境を自動判定します（コンテナ内: 直接実行 / ホスト: docker compose 経由）。
+> ホスト側ではコンテナ起動が前提です。未起動の場合はエラーとなります。
+
+## ログ（開発用）
+- `LOG_LEVEL`（既定: INFO）
+- `LOG_JSON`（既定: true）
+- `LOG_DEBUG_BODY`（既定: false）
+- `LOG_BODY_MAX`（既定: 256）

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,8 +1,11 @@
+import logging
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from backend.middlewares.logging import setup_access_log_middleware
 from backend.routers.mask import router as mask_router
 from backend.services.masker import Masker
 
@@ -22,7 +25,23 @@ async def lifespan(app: FastAPI):
         pass
 
 
-app = FastAPI(title="PersonalMasker API", version="0.1.0", lifespan=lifespan)
+def _configure_logging() -> None:
+    """
+    ログ設定を初期化する。
+    - LOG_LEVEL: 既定 INFO
+    - LOG_JSON: JSON/プレーンはミドルウェア側で整形
+    """
+
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    # 既存ハンドラがある場合は尊重しつつ、最低限の設定を適用
+    logging.basicConfig(level=level)
+
+
+_configure_logging()
+
+
+app = FastAPI(title="PersonalMasker API", lifespan=lifespan)
 
 # CORS (development only)
 app.add_middleware(
@@ -43,6 +62,9 @@ app.add_middleware(
 async def health_check():
     return {"status": "healthy"}
 
+
+# Middlewares
+setup_access_log_middleware(app)
 
 # Routers
 app.include_router(mask_router)

--- a/backend/middlewares/logging.py
+++ b/backend/middlewares/logging.py
@@ -1,0 +1,227 @@
+"""
+アクセスログ用ミドルウェア。
+
+- FastAPI の入出力（メソッド/パス/ステータス/遅延など）を記録
+- 既定では PII を含む原文本文は記録しない（ダイジェストと長さのみ）
+- デバッグ時（`LOG_DEBUG_BODY=true`）のみ原文本文をログに含める
+
+環境変数:
+- LOG_JSON: true/false（JSON 形式で出力）
+- LOG_LEVEL: INFO/DEBUG など（logging レベル）
+- LOG_DEBUG_BODY: true/false（原文本文のログ許可。既定 false）
+- LOG_BODY_MAX: 本文の最大記録長（既定 256）
+- LOG_SAMPLE: サンプリング率 0.0〜1.0（既定 1.0）
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+
+
+def _sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def setup_access_log_middleware(app: FastAPI) -> None:
+    """
+    アクセスログミドルウェアをアプリへ登録する（多重登録は回避）。
+    """
+
+    if getattr(app.state, "_access_log_installed", False):
+        return
+
+    logger = logging.getLogger("app.access")
+
+    @app.middleware("http")
+    async def access_log(request: Request, call_next) -> Response:  # type: ignore[override]
+        start = time.perf_counter()
+
+        # 設定（毎回読む: テストでの切替や動的変更に備える）
+        log_json = os.getenv("LOG_JSON", "true").lower() == "true"
+        debug_body = os.getenv("LOG_DEBUG_BODY", "false").lower() == "true"
+        try:
+            body_max = int(os.getenv("LOG_BODY_MAX", "256"))
+        except Exception:  # noqa: BLE001
+            body_max = 256
+        try:
+            sample = float(os.getenv("LOG_SAMPLE", "1.0"))
+        except Exception:  # noqa: BLE001
+            sample = 1.0
+
+        # 低コストなサンプリング（簡易）: 現状は全件想定
+        _ = sample  # 未使用（将来拡張）
+
+        method = request.method
+        path = request.url.path
+
+        # リクエストID（ヘッダ優先、無ければ採番）
+        request_id = request.headers.get("X-Request-ID") or uuid.uuid4().hex
+        # 後段で参照できるように state にも保存
+        request.state.request_id = request_id
+
+        # タイムスタンプ（UTC, RFC3339）
+        def _now_ts() -> str:
+            # ローカルタイム（コンテナのTZに依存）でISO8601を出力
+            return datetime.now().astimezone().isoformat(timespec="milliseconds")
+        start_ts = _now_ts()
+
+        # リクエスト本文の取得（JSON前提で text を抽出。失敗時は空扱い）
+        req_text: str = ""
+        try:
+            raw = await request.body()
+            # 本文を読み取った場合はダウンストリームでも参照できるように復元する
+            # 1) キャッシュへ格納
+            try:
+                request._body = raw  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                pass
+            # 2) 受信チャネルを差し替え（受信側が body() 以外で読む場合に備える）
+            async def _receive() -> dict[str, Any]:
+                return {"type": "http.request", "body": raw, "more_body": False}
+
+            try:
+                request._receive = _receive  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                pass
+            if raw:
+                # JSON を想定（/mask）
+                try:
+                    obj = json.loads(raw.decode("utf-8"))
+                    if isinstance(obj, dict) and "text" in obj and isinstance(obj["text"], str):
+                        req_text = obj["text"]
+                except Exception:  # noqa: BLE001
+                    # JSON でなければスキップ
+                    req_text = ""
+        except Exception:  # noqa: BLE001
+            req_text = ""
+
+        # 実行前ログ（IN）
+        start_log: dict[str, Any] = {
+            "logger": "app.access",
+            "level": "INFO",
+            "event": "IN",
+            "request_id": request_id,
+            "ts": start_ts,
+            "method": method,
+            "path": path,
+        }
+        if req_text:
+            # 長さは常に記録（プレビュー有無に関わらず）
+            start_log["req_body_len"] = len(req_text)
+            if debug_body:
+                start_log["req_body"] = req_text[:body_max]
+                # 必要に応じてダイジェストも保持（整合性確認用）
+                start_log["req_body_digest"] = _sha256_hex(req_text)
+            else:
+                start_log["req_body_digest"] = _sha256_hex(req_text)
+        _emit(logger, start_log, log_json)
+
+        # ルーティング実行
+        response: Response
+        try:
+            response = await call_next(request)
+            status = response.status_code
+        except Exception as ex:  # noqa: BLE001
+            status = 500
+            # エラーもログして再送出
+            end = time.perf_counter()
+            latency_ms = int((end - start) * 1000)
+            log_obj: dict[str, Any] = {
+                "logger": "app.access",
+                "level": "ERROR",
+                "event": "OUT",
+                "request_id": request_id,
+                "ts": _now_ts(),
+                "method": method,
+                "path": path,
+                "status": status,
+                "latency_ms": latency_ms,
+                "error": ex.__class__.__name__,
+            }
+            if debug_body and req_text:
+                log_obj["req_body"] = req_text[:body_max]
+            else:
+                if req_text:
+                    log_obj["req_body_digest"] = _sha256_hex(req_text)
+                    log_obj["req_body_len"] = len(req_text)
+            _emit(logger, log_obj, log_json)
+            raise
+
+        end = time.perf_counter()
+        latency_ms = int((end - start) * 1000)
+
+        # レスポンス本文を捕捉（後で新しい Response に包み直す）
+        # まず既存レスポンスのヘッダ/属性を保持
+        headers = dict(response.headers)
+        headers.setdefault("X-Request-ID", request_id)
+
+        body_bytes = b""
+        if getattr(response, "body_iterator", None) is not None:
+            async for chunk in response.body_iterator:  # type: ignore[attr-defined]
+                body_bytes += chunk
+        else:
+            try:
+                body_bytes = response.body  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                body_bytes = b""
+
+        # リクエストログ（完了: OUT）
+        log_obj = {
+            "logger": "app.access",
+            "level": "INFO",
+            "event": "OUT",
+            "request_id": request_id,
+            "ts": _now_ts(),
+            "method": method,
+            "path": path,
+            "status": status,
+            "latency_ms": latency_ms,
+        }
+        # OUT ログは本文/ダイジェストともに出力しない（IN のみ記録）。
+
+        _emit(logger, log_obj, log_json)
+
+        # レスポンス付加情報（/mask のみ、masked 情報を安全に要約）
+        if path == "/mask" and body_bytes:
+            try:
+                body_obj = json.loads(body_bytes.decode("utf-8"))
+                if isinstance(body_obj, dict):
+                    masked = body_obj.get("masked")
+                    detected = body_obj.get("detected")
+                    if isinstance(masked, str):
+                        log_obj["masked_len"] = len(masked)
+                        if debug_body:
+                            log_obj["masked_preview"] = masked[:body_max]
+                    if isinstance(detected, list):
+                        log_obj["detected_count"] = len(detected)
+            except Exception:  # noqa: BLE001
+                pass
+
+        # 包み直したレスポンスを返却
+        return Response(
+            content=body_bytes,
+            status_code=status,
+            headers=headers,
+            media_type=response.media_type,
+            background=getattr(response, "background", None),
+        )
+
+    app.state._access_log_installed = True
+
+
+def _emit(logger: logging.Logger, payload: dict[str, Any], as_json: bool) -> None:
+    """ロガーへ出力（JSON文字列 or テキスト）。"""
+    if as_json:
+        logger.info(json.dumps(payload, ensure_ascii=False))
+    else:
+        # テキスト整形（簡易）。キー:値 の並び。
+        parts = [f"{k}={json.dumps(v, ensure_ascii=False)}" for k, v in payload.items()]
+        logger.info(" ".join(parts))

--- a/backend/routers/mask.py
+++ b/backend/routers/mask.py
@@ -1,3 +1,5 @@
+import logging
+
 from fastapi import APIRouter, HTTPException, Request
 
 from backend.schemas.mask import Entity, MaskRequest, MaskResponse
@@ -66,5 +68,6 @@ async def mask_text(payload: MaskRequest, request: Request) -> MaskResponse:
     except HTTPException:
         raise
     except Exception as e:  # noqa: BLE001
-        # 例外の詳細はログなどでトレース（ここでは簡略化）
+        # 例外はアプリロガーへ出力（PIIを含めない）
+        logging.getLogger("app").exception("/mask で例外が発生しました")
         raise HTTPException(status_code=500, detail="内部エラー") from e

--- a/backend/tests/middlewares/test_logging.py
+++ b/backend/tests/middlewares/test_logging.py
@@ -1,0 +1,144 @@
+"""
+アクセスログミドルウェアのユニットテスト（TDD）
+
+- 目的: FastAPI リクエスト/レスポンスの基本項目がログされること
+- PII保護: 既定では原文本文(text)はログに含めない
+- デバッグ時: 環境変数で有効化した場合のみ原文本文をログに含める
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Any
+
+import pytest
+from backend.app import app
+from backend.middlewares.logging import setup_access_log_middleware
+from backend.services.masker import Span
+from fastapi.testclient import TestClient
+
+
+class _FakeMasker:
+    """ルーターの動作を軽量化するための簡易スタブ。"""
+
+    def mask(  # noqa: ARG002 - テスト用の未使用引数を許容
+        self,
+        text: str,
+        targets: list[str] | None,
+        replacement: str,
+        preserve_length: bool,
+        fixed_length: int | None,
+    ) -> tuple[str, list[Span]]:
+        # 未使用引数を明示的に参照して Lint を抑制
+        _ = (targets, fixed_length)
+        # 固定スパン1件（[7, 11)）を返す
+        detected = [Span(start=7, end=11, label="EMAIL", text=text[7:11])]
+        masked = text[:7] + (replacement * (4 if preserve_length else 1)) + text[11:]
+        return masked, detected
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """テスト間でログ関連の環境変数をリセット。"""
+    for k in ["LOG_JSON", "LOG_LEVEL", "LOG_DEBUG_BODY", "LOG_BODY_MAX", "LOG_SAMPLE"]:
+        if k in os.environ:
+            monkeypatch.delenv(k, raising=False)
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def test_access_log_basic_without_body(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """
+    既定（LOG_DEBUG_BODY=false）では原文本文はログに含まず、ダイジェストのみ。
+    """
+    monkeypatch.setenv("LOG_JSON", "true")
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+    monkeypatch.setenv("LOG_DEBUG_BODY", "false")
+    monkeypatch.setenv("LOG_BODY_MAX", "64")
+
+    setup_access_log_middleware(app)
+    # 起動時の Masker 生成を軽量スタブへ差し替え（TestClient 起動前に適用）
+    monkeypatch.setattr("backend.app.Masker", lambda *_args, **_kwargs: _FakeMasker())
+
+    with TestClient(app) as client:
+        client.app.state.masker = _FakeMasker()
+        body = {"text": "太郎のメールは taro@example.com です。"}
+        expect_digest = _digest(body["text"])
+
+        caplog.set_level(logging.INFO, logger="app.access")
+        res = client.post("/mask", json=body)
+        assert res.status_code == 200
+
+        # JSONメッセージを直接パース（caplog.records から message を取得）
+        found_out = False
+        found_in = False
+        for rec in caplog.records:
+            if rec.name != "app.access":
+                continue
+            try:
+                obj: dict[str, Any] = json.loads(rec.getMessage())
+            except Exception:  # noqa: BLE001
+                continue
+            # 完了ログ（OUT）のみを対象に検証
+            if obj.get("path") == "/mask" and obj.get("event") == "OUT":
+                assert obj.get("method") == "POST"
+                assert obj.get("status") == 200
+                # OUT では本文要約は出さない（digest/len ともに不要）
+                assert "req_body_digest" not in obj
+                assert "req_body" not in obj
+                found_out = True
+            # 開始ログ（IN）で長さ/ダイジェストを検証
+            if obj.get("path") == "/mask" and obj.get("event") == "IN":
+                assert obj.get("method") == "POST"
+                assert obj.get("req_body_digest") == expect_digest
+                assert obj.get("req_body_len") == len(body["text"]) + 0
+                assert "req_body" not in obj
+                found_in = True
+        assert found_out, "OUT ログが見つかりませんでした"
+        assert found_in, "IN ログが見つかりませんでした"
+        # ログ全体にも本文は含まれない
+        assert "太郎のメールは" not in caplog.text
+
+
+def test_access_log_with_debug_body(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """
+    デバッグ時（LOG_DEBUG_BODY=true）は原文本文をログに含める。
+    """
+    monkeypatch.setenv("LOG_JSON", "true")
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("LOG_DEBUG_BODY", "true")
+    monkeypatch.setenv("LOG_BODY_MAX", "256")
+
+    setup_access_log_middleware(app)
+    monkeypatch.setattr("backend.app.Masker", lambda *_args, **_kwargs: _FakeMasker())
+
+    with TestClient(app) as client:
+        client.app.state.masker = _FakeMasker()
+        body = {"text": "太郎のメールは taro@example.com です。"}
+
+        caplog.set_level(logging.INFO, logger="app.access")
+        res = client.post("/mask", json=body)
+        assert res.status_code == 200
+
+        # 本文がどこかのログ行に含まれること（JSONの req_body に入る）
+        included = False
+        in_has_len = False
+        for rec in caplog.records:
+            if rec.name != "app.access":
+                continue
+            try:
+                obj: dict[str, Any] = json.loads(rec.getMessage())
+            except Exception:  # noqa: BLE001
+                continue
+            if obj.get("path") == "/mask" and isinstance(obj.get("req_body"), str):
+                if "太郎のメールは" in obj["req_body"]:
+                    included = True
+            if obj.get("path") == "/mask" and obj.get("event") == "IN":
+                if obj.get("req_body_len") == len(body["text"]) + 0:
+                    in_has_len = True
+        assert included, "デバッグ時の本文ログが見つかりませんでした"
+        assert in_has_len, "デバッグ時の IN ログに req_body_len がありません"


### PR DESCRIPTION
## 概要
運用基盤の強化（入出力アクセスログの標準化、テスト実行フロー整備）と README の記述整理を収録したリリースです。  

## 変更内容
- 入出力アクセスログの実装と運用向けロギング整理（IN/OUT、request_id、ローカル時刻、/mask メタ）
  - 参照: [#28](https://github.com/n4cl/PersonalMasker/pull/28)
  - 主な変更: `backend/middlewares/logging.py`, `backend/tests/middlewares/test_logging.py`, `backend/routers/mask.py`, `backend/app.py`, `README.md`
- バックエンドのテスト実行フロー整備（pytest → Ruff をワンコマンド、ホスト/コンテナ自動判定）
  - 参照: [#27](https://github.com/n4cl/PersonalMasker/pull/27)
  - 主な変更: `Makefile`, `backend/README.md`
- README の記述整理（冗長箇所の削減、現状に沿った簡潔な説明へ）
  - 参照: [#30](https://github.com/n4cl/PersonalMasker/pull/30)
  - 主な変更: `README.md`

## 動作確認
- コンテナ起動
  - `docker compose up`
- テスト/リンター（ホスト）
  - `make backend-all`（未起動時はエラー→起動案内、起動後に pytest→Ruff が通る）
- テスト/リンター（コンテナ内 `/usr/local/app`）
  - `make backend-all`（`/opt/venv/bin/pytest` と `/opt/venv/bin/ruff` が実行）
- アクセスログの確認（/mask 実行）
  - 既定: `LOG_DEBUG_BODY=false` → IN に `req_body_len/digest`、OUT は本文要約なし
  - デバッグ: `LOG_DEBUG_BODY=true` → IN に `req_body`（先頭N）+ `req_body_len/digest`、OUT は本文要約なし
- README のレンダリング確認（GitHub 上）
  - 見出し/箇条書き/表/コードブロックに崩れがないこと

## 関連Issue
- Release v0.3.0: [#29](https://github.com/n4cl/PersonalMasker/issues/29)

## 補足情報
- 外部インターフェース（REST API）の仕様変更はありません（/mask の I/O は据え置き）。
- マージ後にタグ `v0.3.0` を作成してください。